### PR TITLE
Add more tests on likelihood and `expected_logtilt`

### DIFF
--- a/src/TestUtils.jl
+++ b/src/TestUtils.jl
@@ -96,37 +96,47 @@ function test_auglik(
 
         @test all(x -> all(>=(0), x), γs) # Check that the variance is positive
 
-        # TODO test that aux_posterior parameters return the minimizing
-        φ = TupleVectors.unwrap(aux_posterior(lik, y, qf).pars) # TupleVector
-        φ_opt = vcat(values(φ)...)
-        s = keys(φ)
-        n_var = length(s)
-        function loss(φ)
-            q = ProductMeasure(
-                qΩ.f,
-                TupleVector(
-                    NamedTuple{s}(
-                        collect(φ[((j - 1) * n_var + 1):(j * n_var)] for j in 1:n_var)
+        @testset "expected_logtilt" begin
+            @test expected_logtilt(lik, qΩ, y, qf) isa Real
+            S = 1000
+            val = expected_logtilt(lik, qΩ, y, qf)
+            fs = [rand(qf) for _ in 1:S]
+            Ωs = [tvrand(qΩ, S) for _ in 1:S]
+            samp_val = mapreduce(+, Ωs, fs) do Ω, f
+                logtilt(lik, Ω, y, f)
+            end / S
+            @test val ≈ samp_val
+        end
+
+        @testset "aux_posterior" begin
+            φ = TupleVectors.unwrap(aux_posterior(lik, y, qf).pars) # TupleVector
+            φ_opt = vcat(values(φ)...)
+            s = keys(φ)
+            n_var = length(s)
+            function loss(φ)
+                q = ProductMeasure(
+                    qΩ.f,
+                    TupleVector(
+                        NamedTuple{s}(
+                            collect(φ[((j - 1) * n_var + 1):(j * n_var)] for j in 1:n_var)
+                        ),
                     ),
-                ),
-            )
-            return -expected_logtilt(lik, q, y, qf) + aux_kldivergence(lik, q, y)
+                )
+                return -expected_logtilt(lik, q, y, qf) + aux_kldivergence(lik, q, y)
+            end
+            ϵ = 1e-2
+            # Test that by perturbing the value in random directions, the loss does not decrease
+            for i in n_var * n
+                (lik isa PoissonLikelihood && i <= n) && continue # We do not want to vary y
+                Δ = zeros(n_var * n)
+                Δ[i] = ϵ # We try one element at a time
+                @test loss(φ_opt) <= loss(φ_opt + Δ)
+                @test loss(φ_opt) <= loss(φ_opt - Δ)
+            end
         end
-        ϵ = 1e-2
-        # Test that by perturbing the value in random directions, the loss does not decrease
-        for i in n_var * n
-            (lik isa PoissonLikelihood && i <= n) && continue # We do not want to vary y
-            Δ = zeros(n_var * n)
-            Δ[i] = ϵ # We try one element at a time
-            @test loss(φ_opt) <= loss(φ_opt + Δ)
-            @test loss(φ_opt) <= loss(φ_opt - Δ)
-        end
-        # Optim.optimize(loss, φ_opt)
-        # values of the ELBO
         pΩ = aux_prior(lik, y)
         @test pΩ isa ProductMeasure
         @test kldivergence(first(marginals(qΩ)), first(marginals(pΩ))) isa Real
-        @test expected_logtilt(lik, qΩ, y, qf) isa Real
         @test aux_kldivergence(lik, qΩ, pΩ) isa Real
     end
 end

--- a/src/TestUtils.jl
+++ b/src/TestUtils.jl
@@ -18,6 +18,16 @@ function test_auglik(
 )
     y = rand.(rng, lik.(f))
     nf = nlatent(lik)
+    @testset "Augmentation test" begin
+        S = 100_000
+        orig_lik = lik(f)
+        orig_pdf = pdf(orig_lik, y)
+        aux_dist = aux_prior(lik, y)
+        aug_pdf = mapreduce(+, [tvrand(aux_dist) for _ in 1:S]) do Ω
+            exp(logtilt(lik, Ω, y, f))
+        end / S
+        @test orig_pdf ≈ aug_pdf
+    end
     # Testing sampling
     @testset "Sampling" begin
         Ω = init_aux_variables(lik, n)


### PR DESCRIPTION
- Check that the augmented likelihood is valid when marginalizing out `\Omega` (via sampling)
- Check that the expected logtilt function is correct by evaluating the expectation with sampling.