### PR TITLE
Allow use of `ForwardDiff` and `ReverseDiff` to calculate gradient of augmented ELBO

### DIFF
--- a/src/AugmentedGPLikelihoods.jl
+++ b/src/AugmentedGPLikelihoods.jl
@@ -2,7 +2,7 @@ module AugmentedGPLikelihoods
 
 using Reexport
 
-using ChainRulesCore: @ignore_derivatives
+using ChainRulesCore: @ignore_derivatives, ignore_derivatives
 using Distributions
 @reexport using GPLikelihoods
 using GPLikelihoods: AbstractLikelihood, AbstractLink

--- a/src/likelihoods/bernoulli.jl
+++ b/src/likelihoods/bernoulli.jl
@@ -14,6 +14,13 @@ function aux_full_conditional(::BernoulliLikelihood{<:LogisticLink}, ::Any, f::R
     return NTDist(PolyaGamma(1, abs(f)))
 end
 
+function aux_posterior(lik::BernoulliLikelihood{<:LogisticLink}, y, f)
+    c = map(sqrt ∘ second_moment, f)
+    return For(TupleVector(; c=c)) do φ
+        NTDist(PolyaGamma(1, φ.c))
+    end
+end
+
 function aux_posterior!(
     qΩ,
     ::BernoulliLikelihood{<:LogisticLink},

--- a/src/likelihoods/laplace.jl
+++ b/src/likelihoods/laplace.jl
@@ -41,6 +41,14 @@ function aux_full_conditional(lik::LaplaceLikelihood, y::Real, f::Real)
     return NTDist(InverseGaussian(inv(2 * lik.β * abs(y - f)), 2 * laplace_λ(lik)))
 end
 
+function aux_posterior(lik::LaplaceLikelihood, y, f)
+    λ = laplace_λ(lik)
+    μ = inv.(2 .* lik.β .* sqrt.(second_moment.(f, y)))
+    return For(TupleVector(; μ=μ)) do φ
+        NTDist(InverseGaussian(φ.μ, λ))
+    end
+end
+
 function aux_posterior!(
     qΩ, lik::LaplaceLikelihood, y::AbstractVector, qf::AbstractVector{<:Normal}
 )

--- a/src/likelihoods/negativebinomial.jl
+++ b/src/likelihoods/negativebinomial.jl
@@ -39,6 +39,13 @@ function aux_full_conditional(lik::NegBinomialLikelihood, y::Real, f::Real)
     return NTDist(PolyaGamma(y + lik.r, abs(f)))
 end
 
+function aux_posterior(lik::NegBinomialLikelihood, y, f)
+    c = sqrt.(second_moment.(f))
+    return For(TupleVector(; y=y, c=c)) do φ
+        NTDist(PolyaGamma(φ.y + lik.r, φ.c)) # Distributions uses a different parametrization
+    end
+end
+
 function aux_posterior!(
     qΩ, ::NegBinomialLikelihood, y::AbstractVector, qf::AbstractVector{<:Normal}
 )

--- a/src/likelihoods/poisson.jl
+++ b/src/likelihoods/poisson.jl
@@ -27,6 +27,15 @@ function aux_full_conditional(lik::AugPoisson, y::Int, f::Real)
     return PolyaGammaPoisson(y, abs(f), lik.invlink(-f))
 end
 
+function aux_posterior(lik::AugPoisson, y, f)
+    λ = lik.invlink.λ
+    c = sqrt.(second_moment.(f))
+    λ_vector = @. λ * approx_expected_logistic(-mean(f), c)
+    return For(TupleVector(; y=y, c=c, λ=λ_vector)) do q
+        PolyaGammaPoisson(q.y, q.c, q.λ)
+    end
+end
+
 function aux_posterior!(
     qΩ, lik::AugPoisson, y::AbstractVector{<:Int}, qf::AbstractVector{<:Normal}
 )

--- a/src/likelihoods/studentt.jl
+++ b/src/likelihoods/studentt.jl
@@ -11,14 +11,14 @@ Likelihood with a Student-T likelihood:
 - `ν::Real`, number of degrees of freedom, should be positive and larger than 0.5 to be able to compute moments
 - `σ::Real`, scaling of the inputs.
 """
-struct StudentTLikelihood{Tν<:Real,Tσ<:Real,Thalfν<:Real} <: AbstractLikelihood
+struct StudentTLikelihood{Tν,Tσ,Tσ2,Thalfν} <: AbstractLikelihood
     ν::Tν
     σ::Tσ
-    σ²::Tσ
+    σ²::Tσ2
     halfν::Thalfν
 end
 
-StudentTLikelihood(ν::Real, σ::Real) = StudentTLikelihood(ν, σ, abs2(σ), ν / 2)
+StudentTLikelihood(ν, σ) = StudentTLikelihood(ν, σ, abs2(σ), ν / 2)
 
 (lik::StudentTLikelihood)(f::Real) = Distributions.AffineDistribution(f, lik.σ, TDist(lik.ν))
 

--- a/src/likelihoods/studentt.jl
+++ b/src/likelihoods/studentt.jl
@@ -46,6 +46,7 @@ function aux_full_conditional(lik::StudentTLikelihood, y::Real, f::Real)
 end
 
 function aux_posterior(lik::StudentTLikelihood, y, f)
+    α = _α(lik)
     β = map(y, f) do yᵢ, fᵢ
         (lik.ν / abs2(lik.σ) + second_moment(fᵢ, yᵢ)) / 2
     end

--- a/src/likelihoods/studentt.jl
+++ b/src/likelihoods/studentt.jl
@@ -45,6 +45,15 @@ function aux_full_conditional(lik::StudentTLikelihood, y::Real, f::Real)
     return NTDist(Gamma(_α(lik), 2 / (lik.ν / abs2(lik.σ) + abs2(y - f))))
 end
 
+function aux_posterior(lik::StudentTLikelihood, y, f)
+    β = map(y, f) do yᵢ, fᵢ
+        (lik.ν / abs2(lik.σ) + second_moment(fᵢ, yᵢ)) / 2
+    end
+    return For(TupleVector(; β=β)) do φ
+        NTDist(Gamma(α, inv(φ.β))) # Distributions uses a different parametrization
+    end
+end
+
 function aux_posterior!(
     qΩ, lik::StudentTLikelihood, y::AbstractVector, qf::AbstractVector{<:Normal}
 )

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -9,6 +9,8 @@ end
 # This is not exactly an approximation but corresponds anyway
 # to the expectation of the function σ(f)
 function approx_expected_logistic(μ, c)
-    lower, upper = LogExpFunctions._logistic_bounds(μ)
+    lower, upper = ignore_derivatives() do 
+        LogExpFunctions._logistic_bounds(μ)
+    end
     return μ < lower ? zero(μ) : (μ > upper ? one(μ) : exp(μ / 2) * sech(c / 2) / 2)
 end

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,9 +1,13 @@
 [deps]
+ApproximateGPs = "298c2ebc-0411-48ad-af38-99e88101b606"
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
+ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 GPLikelihoods = "6031954c-0455-49d7-b3b9-3e1c99afaf40"
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 LogExpFunctions = "2ab3a3ac-af41-5b50-aa03-7779005ae688"
 MeasureBase = "fa1605e6-acd5-459c-a1e6-7e635759db14"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+ReverseDiff = "37e2e3b7-166d-5795-8a7a-e32c996b4267"
 SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 StatsFuns = "4c63d2b9-4356-54db-8cca-17b64c39e42c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/likelihoods/bernoulli.jl
+++ b/test/likelihoods/bernoulli.jl
@@ -1,3 +1,22 @@
 @testset "Bernoulli{<:LogisticLink}" begin
     test_auglik(BernoulliLikelihood(LogisticLink()))
+    @testset "Augmented ELBO /w AD" begin
+        N = 10
+        x = 1:N
+        y = ones(Int, N)
+        function loss(θ)
+            k = ScaledKernel(
+                RBFKernel() ∘ ScaleTransform(inv(θ[1])), 
+                θ[2]
+            )
+            gp = GP(k)
+            lik = BernoulliLikelihood(LogisticLink())
+            fz = gp(x, 1e-8);
+            u_post = u_posterior(fz, fill(θ[3], N), Matrix{Float64}(I(N)))
+            return aug_elbo(lik, u_post, x, y)
+        end
+        θ0 = [1., 2., 3.]
+        @test loss(θ0) ≈ -17.353705091653595
+        @test ForwardDiff.gradient(loss, θ0) ≈ ReverseDiff.gradient(loss, θ0)
+    end
 end

--- a/test/likelihoods/laplace.jl
+++ b/test/likelihoods/laplace.jl
@@ -7,4 +7,23 @@
     μ = rand()
     @test kldivergence(InverseGaussian(μ, 2λ), InverseGamma(1//2, λ)) ≈
         (log(2λ) / 2 - log(2π) / 2 - log(λ) / 2 + loggamma(1//2) + λ / μ)
+    @testset "Augmented ELBO /w AD" begin
+        N = 10
+        x = 1:N
+        y = 1:N
+        function loss(θ)
+            k = ScaledKernel(
+                RBFKernel() ∘ ScaleTransform(inv(θ[1])), 
+                θ[2]
+            )
+            gp = GP(k)
+            lik = LaplaceLikelihood(θ[3])
+            fz = gp(x, 1e-8);
+            u_post = u_posterior(fz, fill(θ[4], N), Matrix{Float64}(I(N)))
+            return aug_elbo(lik, u_post, x, y)
+        end
+        θ0 = [1., 2., 3., 4.]
+        @test loss(θ0) ≈ -51.95433668026266
+        @test ForwardDiff.gradient(loss, θ0) ≈ ReverseDiff.gradient(loss, θ0)
+    end
 end

--- a/test/likelihoods/negativebinomial.jl
+++ b/test/likelihoods/negativebinomial.jl
@@ -2,4 +2,23 @@
     test_interface(NegBinomialLikelihood(10.0), NegativeBinomial)
     test_auglik(NegBinomialLikelihood(LogisticLink(), 10))
     test_auglik(NegBinomialLikelihood(LogisticLink(), 5.5))
+    @testset "Augmented ELBO /w AD" begin
+        N = 10
+        x = 1:N
+        y = 1:N
+        function loss(θ)
+            k = ScaledKernel(
+                RBFKernel() ∘ ScaleTransform(inv(θ[1])), 
+                θ[2]
+            )
+            gp = GP(k)
+            lik = NegBinomialLikelihood(θ[3])
+            fz = gp(x, 1e-8);
+            u_post = u_posterior(fz, fill(θ[4], N), Matrix{Float64}(I(N)))
+            return aug_elbo(lik, u_post, x, y)
+        end
+        θ0 = [1., 2., 3., 4.]
+        @test loss(θ0) ≈ -120.79263407666528
+        @test ForwardDiff.gradient(loss, θ0) ≈ ReverseDiff.gradient(loss, θ0)
+    end
 end

--- a/test/likelihoods/poisson.jl
+++ b/test/likelihoods/poisson.jl
@@ -1,3 +1,22 @@
 @testset "Poisson{<:ScaledLogisticLink}" begin
     test_auglik(PoissonLikelihood(ScaledLogistic(10.0)))
+    @testset "Augmented ELBO /w AD" begin
+        N = 10
+        x = 1:N
+        y = 1:N
+        function loss(θ)
+            k = ScaledKernel(
+                RBFKernel() ∘ ScaleTransform(inv(θ[1])), 
+                θ[2]
+            )
+            gp = GP(k)
+            lik = PoissonLikelihood(ScaledLogistic(θ[3]))
+            fz = gp(x, 1e-8);
+            u_post = u_posterior(fz, fill(θ[4], N), Matrix{Float64}(I(N)))
+            return aug_elbo(lik, u_post, x, y)
+        end
+        θ0 = [1., 2., 3., 4.]
+        @test loss(θ0) ≈ -61.4626187223969
+        @test ForwardDiff.gradient(loss, θ0) ≈ ReverseDiff.gradient(loss, θ0)
+    end
 end

--- a/test/likelihoods/studentt.jl
+++ b/test/likelihoods/studentt.jl
@@ -17,7 +17,7 @@
             return aug_elbo(lik, u_post, x, y)
         end
         θ0 = [1., 2., 3., 4., 5.]
-        @test loss(θ0) ≈ -51.95433668026266
+        @test loss(θ0) ≈ -99.78413403563133
         @test ForwardDiff.gradient(loss, θ0) ≈ ReverseDiff.gradient(loss, θ0)
     end
 end

--- a/test/likelihoods/studentt.jl
+++ b/test/likelihoods/studentt.jl
@@ -1,4 +1,23 @@
 @testset "StudentT" begin
     test_interface(StudentTLikelihood(3.0, 1.5), Distributions.AffineDistribution{Float64,Continuous,<:TDist})
     test_auglik(StudentTLikelihood(3.0, 1.5))
+    @testset "Augmented ELBO /w AD" begin
+        N = 10
+        x = 1:N
+        y = 1:N
+        function loss(θ)
+            k = ScaledKernel(
+                RBFKernel() ∘ ScaleTransform(inv(θ[1])), 
+                θ[2]
+            )
+            gp = GP(k)
+            lik = StudentTLikelihood(θ[3], θ[4])
+            fz = gp(x, 1e-8);
+            u_post = u_posterior(fz, fill(θ[5], N), Matrix{Float64}(I(N)))
+            return aug_elbo(lik, u_post, x, y)
+        end
+        θ0 = [1., 2., 3., 4., 5.]
+        @test loss(θ0) ≈ -51.95433668026266
+        @test ForwardDiff.gradient(loss, θ0) ≈ ReverseDiff.gradient(loss, θ0)
+    end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,16 +1,31 @@
+using ApproximateGPs
 using AugmentedGPLikelihoods
 using AugmentedGPLikelihoods.SpecialDistributions
 using AugmentedGPLikelihoods.TestUtils: test_auglik
 const AGPL = AugmentedGPLikelihoods
 using Distributions
+using ForwardDiff
 using GPLikelihoods
 using GPLikelihoods.TestInterface: test_interface
+using LinearAlgebra: I
 using MeasureBase
 using LogExpFunctions
 using Random
+using ReverseDiff
 using SpecialFunctions
 using Test
 using TupleVectors
+
+function aug_elbo(lik, u_post, x, y)
+    qf = ApproximateGPs.marginals(u_post(x))
+    qΩ = aux_posterior(lik, y, qf)
+    return expected_logtilt(lik, qΩ, y, qf) - aux_kldivergence(lik, qΩ, y) -
+           kldivergence(u_post.approx.q, u_post.approx.fz)     # approx.fz is the prior and approx.q is the posterior 
+end
+
+function u_posterior(fz, m, S)
+    return posterior(SparseVariationalApproximation(Centered(), fz, MvNormal(m, S)))
+end
 
 @testset "AugmentedGPLikelihoods.jl" begin
     @info "Testing likelihoods"


### PR DESCRIPTION
The Poisson case does not work yet because I haven't yet managed to figure out how to make it ignore the derivative of `LogExpFunctions._logistic_bounds`, which depends only on the type and is therefore constant. One way to solve this would be to add explicit overloads for `ForwardDiff.Dual` etc., but this adds dependencies.

I had to remove a few type restrictions, while they shouldn't break anything they offer less protection for users.

After the Poisson case is fixed, this closes #76.